### PR TITLE
Fix build error

### DIFF
--- a/DataUpdateMethods/Program.cs
+++ b/DataUpdateMethods/Program.cs
@@ -15,7 +15,7 @@ namespace DataUpdateMethods
         public static void Main(string[] args)
         {
             var host = CreateHostBuilder(args).Build();
-            var summary = host.Services.GetRequiredService<BenchmarkRunner>().Run<UpDateData>();
+            BenchmarkRunner.Run<UpDateData>();
             Console.ReadKey();
         }
 


### PR DESCRIPTION
Fix the build error by removing the use of a static type as a type argument.

* Remove `var summary = host.Services.GetRequiredService<BenchmarkRunner>().Run<UpDateData>();` line.
* Add `BenchmarkRunner.Run<UpDateData>();` in the `Main` method.

