### PR TITLE
Fix the build error

### DIFF
--- a/DataUpdateMethods/Program.cs
+++ b/DataUpdateMethods/Program.cs
@@ -23,8 +23,7 @@ namespace DataUpdateMethods
             Host.CreateDefaultBuilder(args)
                 .ConfigureServices((_, services) =>
                     services.AddDbContext<WideWorldImportersContext>()
-                            .AddTransient<UpDateData>()
-                            .AddTransient<BenchmarkRunner>());
+                            .AddTransient<UpDateData>());
     }
 
     [RPlotExporter]


### PR DESCRIPTION
Fix the build error 'static types cannot be used as type arguments' in `DataUpdateMethods/Program.cs`.

* Remove `.AddTransient<BenchmarkRunner>()` from `CreateHostBuilder`.
* Use `BenchmarkRunner.Run<UpDateData>();` directly in `Main`.

